### PR TITLE
fix: conditional logging for database creation on startup.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -36,9 +36,7 @@ bot = commands.Bot(command_prefix=configs['prefix'], intents=intents)
 
 @bot.event
 async def on_ready():
-    if not (os.path.isfile(os.path.join(os.getenv('DATA_PATH'), 'tracked_accounts.db'))):
-        await init_db()
-        
+    await init_db()
     check_upgrade()
         
     invalid_clients = await check_db()

--- a/src/db_function/init_db.py
+++ b/src/db_function/init_db.py
@@ -9,10 +9,14 @@ log = setup_logger(__name__)
 
 
 async def init_db():
-    if not os.path.exists(os.getenv('DATA_PATH')):
-        os.mkdir(os.getenv('DATA_PATH'))
+    data_path = os.getenv('DATA_PATH')
+    if not os.path.exists(data_path):
+        os.mkdir(data_path)
 
-    async with aiosqlite.connect(os.path.join(os.getenv('DATA_PATH'), 'tracked_accounts.db')) as db:
+    db_path = os.path.join(data_path, 'tracked_accounts.db')
+    db_exists = os.path.exists(db_path)
+
+    async with aiosqlite.connect(db_path) as db:
         await db.executescript("""
             CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, username TEXT, latest_tweet TEXT, client_used TEXT, enabled INTEGER DEFAULT 1);
             CREATE TABLE IF NOT EXISTS channel (id TEXT PRIMARY KEY, server_id TEXT);
@@ -21,7 +25,8 @@ async def init_db():
         """)
         await db.commit()
 
-    log.info('database file not found, a blank database file has been created')
+    if not db_exists:
+        log.info('database file not found, a blank database file has been created')
 
 
 async def init_latest_tweet_on_startup(db_path: str):

--- a/src/db_function/init_db.py
+++ b/src/db_function/init_db.py
@@ -15,6 +15,8 @@ async def init_db():
 
     db_path = os.path.join(data_path, 'tracked_accounts.db')
     db_exists = os.path.exists(db_path)
+    
+    if db_exists: return
 
     async with aiosqlite.connect(db_path) as db:
         await db.executescript("""
@@ -25,8 +27,7 @@ async def init_db():
         """)
         await db.commit()
 
-    if not db_exists:
-        log.info('database file not found, a blank database file has been created')
+    log.info('database file not found, a blank database file has been created')
 
 
 async def init_latest_tweet_on_startup(db_path: str):


### PR DESCRIPTION
I noticed that even when tracked accounts already exist, the bot prints a message: `database file not found, a blank database file has been created` every time it starts up.

This PR modifies `init_db()` to check if the `tracked_accounts.db` file exists before connecting. The log message is now only displayed when the database file is truly missing (e.g., during the first-time setup), preventing users from thinking their database has been reset or deleted.