### PR TITLE
fix(sync): skip disabled users and unconfigured clients in /sync

### DIFF
--- a/cogs/sync.py
+++ b/cogs/sync.py
@@ -25,7 +25,7 @@ class Sync(Cog_Extension):
 
         async with connect_readonly(os.path.join(os.getenv('DATA_PATH'), 'tracked_accounts.db')) as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute('SELECT id, client_used FROM user') as cursor:
+            async with db.execute('SELECT id, client_used FROM user WHERE enabled = 1') as cursor:
                 follow_list = {row[0]: row[1] async for row in cursor}
 
         self.bot.loop.create_task(sync_db(follow_list))

--- a/src/sync_db/sync_db.py
+++ b/src/sync_db/sync_db.py
@@ -18,8 +18,11 @@ async def sync_db(follow_list: dict[str, str]) -> None:
         apps[account_name] = app
 
     for user_id, client_used in follow_list.items():
-        app = apps[client_used]
-        
+        app = apps.get(client_used)
+        if app is None:
+            log.warning(f'client "{client_used}" for user {user_id} is not configured, skip synchronization')
+            continue
+
         try:
             await app.follow_user(user_id)
             await app.enable_user_notification(user_id)

--- a/test/sync_query.py
+++ b/test/sync_query.py
@@ -1,0 +1,69 @@
+import os
+import sqlite3
+import asyncio
+import unittest
+import sys
+from unittest.mock import patch, MagicMock, AsyncMock
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.sync_db.sync_db import sync_db
+
+# Schema mirrored from src/db_function/init_db.py
+USER_SCHEMA = 'CREATE TABLE user (id TEXT PRIMARY KEY, username TEXT, latest_tweet TEXT, client_used TEXT, enabled INTEGER DEFAULT 1)'
+
+# Query used by /sync to build its follow list (cogs/sync.py). Kept in sync with that command.
+SYNC_FOLLOW_QUERY = 'SELECT id, client_used FROM user WHERE enabled = 1'
+
+
+class TestSyncFollowQuery(unittest.TestCase):
+    """/sync must skip soft-deleted (enabled = 0) accounts, or it re-follows removed users."""
+
+    def setUp(self):
+        self.db = sqlite3.connect(':memory:')
+        self.db.execute(USER_SCHEMA)
+        self.db.executemany(
+            'INSERT INTO user (id, username, client_used, enabled) VALUES (?, ?, ?, ?)',
+            [
+                ('1', 'kept',    'clientA', 1),
+                ('2', 'removed', 'clientA', 0),  # soft-deleted via /remove notifier
+                ('3', 'kept2',   'clientB', 1),
+            ],
+        )
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_excludes_disabled_users(self):
+        rows = self.db.execute(SYNC_FOLLOW_QUERY).fetchall()
+        ids = {r[0] for r in rows}
+        self.assertEqual(ids, {'1', '3'})
+        self.assertNotIn('2', ids)  # the removed account must not be re-followed
+
+
+class TestSyncDbUnconfiguredClient(unittest.IsolatedAsyncioTestCase):
+    """sync_db must skip users whose client token is no longer configured, not crash the whole sync."""
+
+    async def test_skips_unconfigured_client_and_continues(self):
+        follow_list = {'userX': 'known', 'userY': 'gone'}  # 'gone' is not in TWITTER_TOKEN anymore
+
+        app_mock = MagicMock()
+        app_mock.connect = AsyncMock()
+        app_mock.follow_user = AsyncMock()
+        app_mock.enable_user_notification = AsyncMock()
+
+        with patch('src.sync_db.sync_db.get_accounts', return_value={'known': 'token'}), \
+             patch('src.sync_db.sync_db.Twitter', return_value=app_mock), \
+             patch('src.sync_db.sync_db.asyncio.sleep', new=AsyncMock()):
+            # Must not raise KeyError on 'gone'
+            await sync_db(follow_list)
+
+        # Known client is synced; unconfigured one is skipped, not fatal.
+        app_mock.follow_user.assert_awaited_once_with('userX')
+        app_mock.enable_user_notification.assert_awaited_once_with('userX')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`/sync` re-follows and re-enables Twitter notifications for accounts that were removed via `/remove notifier`.

`/remove notifier` is a soft delete: it sets `user.enabled = 0` and (when `auto_unfollow` / `auto_turn_off_notification` are on) unfollows the account and turns off its Twitter notifications. Every other query in the codebase that iterates users filters on `enabled = 1` — `account_tracker.py:91`, `presence_updater.py:14`, `list_users.py:86`, and all of `notification.py`. The `/sync` query in `cogs/sync.py` is the only one that doesn't:

```py
SELECT id, client_used FROM user   # also returns the enabled = 0 (removed) rows
```

So running `/sync` walks every soft-deleted account and calls `follow_user` + `enable_user_notification` on it, silently undoing the removal on the Twitter side.

## Secondary issue (same command path)

In `src/sync_db/sync_db.py`, `app = apps[client_used]` sits **outside** the `try`. `apps` is built only from the currently-configured `TWITTER_TOKEN` accounts, so if a user row references a client whose token was later removed from `.env`, this raises `KeyError` and kills the **entire** background sync task on the first offending row — every remaining account is then silently never synced. (`auto_repair_mismatched_clients` defaults to `false` and only runs at startup, so stale `client_used` values routinely persist.)

## Fix

- `cogs/sync.py` — add `WHERE enabled = 1` to the follow-list query, consistent with the rest of the codebase.
- `src/sync_db/sync_db.py` — look the client up with `.get()` and `continue` with a warning when it isn't configured, instead of crashing the whole sync.

## Test

Adds `test/sync_query.py` (stdlib `unittest`, matching the existing `test/` style):
- the follow-list query excludes `enabled = 0` users
- `sync_db` skips an unconfigured client and still syncs the valid ones (no `KeyError`)

```
python test/sync_query.py
```